### PR TITLE
Make NewType and Extractor irrefutable extractors

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ libraryDependencies += "org.rudogma" %%% "supertagged" % "2.0-RC2"
 # Bytecode
 
 For those who want to check bytecode, have a look at
-- [ShowMeByteCode.scala](https://github.com/Rudogma/scala-supertagged/blob/master/shared/src/test/scala/supertaggedtests/misc/ShowMeByteCode.scala)
-- [ShowMeByteCode.javap.txt](https://github.com/Rudogma/scala-supertagged/blob/master/shared/src/test/scala/supertaggedtests/misc/ShowMeByteCode.javap.txt)
+- [ShowMeByteCode.scala](https://github.com/rudogma/scala-supertagged/blob/master/tests/src/test/scala/supertaggedtests/misc/ShowMeByteCode.scala)
+- [ShowMeByteCode.javap.txt](https://github.com/rudogma/scala-supertagged/blob/master/tests/src/test/scala/supertaggedtests/misc/ShowMeByteCode.javap.txt)
 
 
 

--- a/src/main/scala/supertagged/package.scala
+++ b/src/main/scala/supertagged/package.scala
@@ -89,7 +89,7 @@ package object supertagged {
     /**
      * Thanks @eld0727 from https://t.me/scala_ru for feature request
      */
-    final def unapply(v: Type): Option[T] = Some(v)
+    final def unapply(v: Type): Some[T] = Some(v)
 
 
     final def untag[C](c:C)(implicit R:Remove[C,T,Tag]):R.Out = unsafeCast(c)
@@ -194,7 +194,7 @@ package object supertagged {
 
     @inline final def raw(c:Type):T = unsafeCast(c)
 
-    @inline final def unapply(v: Type): Option[T] = Some(v.asInstanceOf[T])
+    @inline final def unapply(v: Type): Some[T] = Some(v.asInstanceOf[T])
 
     @inline def lift[F[_]](implicit F:F[T]):F[Type] = unsafeCast(F)
   }
@@ -224,7 +224,7 @@ package object supertagged {
     /**
       * Potentially unsafe if you will use it elsewhere except `match` block
       */
-    final def unapply(b:T):Option[Raw] = Some(unsafeCast(b))
+    final def unapply(b:T):Some[Raw] = Some(unsafeCast(b))
   }
   object Extractor {
     private val stub = new Extractor[Any,Any]()


### PR DESCRIPTION
TL;DR: This way they won't disable exhaustiveness checking.

The documentation for irrefutable extractors is pretty terse in the [2.12 spec](https://www.scala-lang.org/files/archive/spec/2.12/08-pattern-matching.html#irrefutable-patterns), but the use of `Some` explicitly called out in the [2.13 spec](https://www.scala-lang.org/files/archive/spec/2.13/08-pattern-matching.html#irrefutable-patterns) should still work in 2.12.

This change shouldn't cause any trouble in earlier versions (tested as far back as 2.10.6)